### PR TITLE
PUSH-1016 PHP 5.6 Variable References Error

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -254,7 +254,8 @@ if ( ! function_exists('get_config'))
 			}
 		}
 
-		return $_config[0] =& $config;
+		$_config[0] =& $config;
+		return $_config[0];
 	}
 }
 
@@ -513,16 +514,16 @@ if ( ! function_exists('remove_invisible_characters'))
 	function remove_invisible_characters($str, $url_encoded = TRUE)
 	{
 		$non_displayables = array();
-		
+
 		// every control character except newline (dec 10)
 		// carriage return (dec 13), and horizontal tab (dec 09)
-		
+
 		if ($url_encoded)
 		{
 			$non_displayables[] = '/%0[0-8bcef]/';	// url encoded 00-08, 11, 12, 14, 15
 			$non_displayables[] = '/%1[0-9a-f]/';	// url encoded 16-31
 		}
-		
+
 		$non_displayables[] = '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]+/S';	// 00-08, 11, 12, 14-31, 127
 
 		do


### PR DESCRIPTION
#### Changes:
* Split return statement into 2 lines to avoid PHP 5.6 warning - fixes issue where errors wouldn't make it into the CodeIgniter log, and therefore not Rollbar
* This was updated in CodeIgniter 2.2.1, but I did not try upgrading that since we're using a custom branch
* Some auto-fixed whitespace

#### Testing:
- Test in concert with [PR-3708](https://github.com/pushoperations/push-operations/pull/3708)