### PR TITLE
PUSH-17358 Session Cookie Workaround

### DIFF
--- a/system/libraries/Session.php
+++ b/system/libraries/Session.php
@@ -673,6 +673,8 @@ class CI_Session {
 					$this->cookie_domain,
 					$this->cookie_secure
 				);
+
+		$_COOKIE[$this->sess_cookie_name] = $cookie_data;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
 #### Changes:
- Update request CI session cookie each time a return cookie is set, to work around our practice of multiple CI_Controllers
- Single CI_Controller routes should be unaffected